### PR TITLE
Fix cisco temperature warning detection

### DIFF
--- a/plugins-scripts/Classes/Cisco/CISCOENVMONMIB/Component/TemperatureSubsystem.pm
+++ b/plugins-scripts/Classes/Cisco/CISCOENVMONMIB/Component/TemperatureSubsystem.pm
@@ -25,7 +25,8 @@ sub finish {
 sub check {
   my ($self) = @_;
   if ($self->{ciscoEnvMonTemperatureStatusValue} >
-      $self->{ciscoEnvMonTemperatureThreshold}) {
+      $self->{ciscoEnvMonTemperatureThreshold}
+      || $self->{ciscoEnvMonTemperatureState} ne 'normal') {
     $self->add_info(sprintf 'temperature %d %s is too high (%d of %d max = %s)',
         $self->{ciscoEnvMonTemperatureStatusIndex},
         $self->{ciscoEnvMonTemperatureStatusDescr},
@@ -48,8 +49,8 @@ sub check {
   $self->add_perfdata(
       label => sprintf('temp_%s', $self->{ciscoEnvMonTemperatureStatusIndex}),
       value => $self->{ciscoEnvMonTemperatureStatusValue},
-      warning => $self->{ciscoEnvMonTemperatureThreshold},
-      critical => undef,
+      warning => undef,
+      critical => $self->{ciscoEnvMonTemperatureThreshold},
   );
 }
 

--- a/plugins-scripts/Classes/Cisco/WLC/Component/TemperatureSubsystem.pm
+++ b/plugins-scripts/Classes/Cisco/WLC/Component/TemperatureSubsystem.pm
@@ -28,7 +28,8 @@ sub finish {
 sub check {
   my ($self) = @_;
   if ($self->{ciscoEnvMonTemperatureStatusValue} >
-      $self->{ciscoEnvMonTemperatureThreshold}) {
+      $self->{ciscoEnvMonTemperatureThreshold}
+      || $self->{ciscoEnvMonTemperatureState} ne 'normal') {
     $self->add_info(sprintf 'temperature %d %s is too high (%d of %d max = %s)',
         $self->{ciscoEnvMonTemperatureStatusIndex},
         $self->{ciscoEnvMonTemperatureStatusDescr},
@@ -51,8 +52,8 @@ sub check {
   $self->add_perfdata(
       label => sprintf('temp_%s', $self->{ciscoEnvMonTemperatureStatusIndex}),
       value => $self->{ciscoEnvMonTemperatureStatusValue},
-      warning => $self->{ciscoEnvMonTemperatureThreshold},
-      critical => undef,
+      warning => undef,
+      critical => $self->{ciscoEnvMonTemperatureThreshold},
   );
 }
 


### PR DESCRIPTION
Related to issue #251

ciscoEnvMonTemperatureThreshold is the critical threshold, therefore warning state is not detected

I've been told that the critical threshold is set by manufacturer and cannot be changed. And the warning threshold is a configurable value as a delta °C below critical threshold. I have not been able to find this warning delta value in the snmp mib.